### PR TITLE
CFEP-18: Remove static libraries from main build

### DIFF
--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -6,5 +6,3 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2017
-vc:
-- '14'

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,17 +24,3 @@ if errorlevel 1 exit 1
 
 nmake install
 if errorlevel 1 exit 1
-
-@rem Build static libraries, install as re2_static.lib
-cmake -DBUILD_SHARED_LIBS=OFF ^
-      -DCMAKE_BUILD_TYPE=Release ^
-      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-      -G "NMake Makefiles" ^
-      %SRC_DIR%
-if errorlevel 1 exit 1
-
-nmake
-if errorlevel 1 exit 1
-
-copy re2.lib %LIBRARY_LIB%\re2_static.lib
-if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,4 +6,4 @@ export CXXFLAGS="-fPIC ${CXXFLAGS}"
 export CFLAGS="-fPIC ${CFLAGS}"
 
 # Build shared libraries
-make -j "${CPU_COUNT}" prefix=${PREFIX} install
+make -j "${CPU_COUNT}" prefix=${PREFIX} shared-install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
-  skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("re2", max_pin="x.x.x") }}
 
@@ -32,12 +31,12 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libre2.so  # [linux]
     - test -f ${PREFIX}/lib/libre2.dylib  # [osx]
-    - test -f ${PREFIX}/lib/libre2.a  # [unix]
+    - test ! -f ${PREFIX}/lib/libre2.a  # [unix]
     - test -f ${PREFIX}/lib/pkgconfig/re2.pc  # [unix]
     - test -f ${PREFIX}/include/re2/re2.h  # [unix]
     - if not exist %PREFIX%\\Library\\include\\re2\\re2.h exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\re2.lib exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\re2_static.lib exit 1  # [win]
+    - if exist %PREFIX%\\Library\\lib\\re2_static.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\bin\\re2.dll exit 1  # [win]
 
 about:


### PR DESCRIPTION
This removes the static libraries from the main package according to [CFEP-18](https://github.com/conda-forge/cfep/pull/34). This might break some downstream builds but this is intended and we should fix the downstream builds to use the shared libraries before adding an output here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
