### PR TITLE
Add cmake-based build to produce a CMake config

### DIFF
--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/llvm_rc,conda-forge,https://conda-web.anaconda.org/conda-forge
+- conda-forge/label/llvm_rc,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
-set -e
-set -x
+set -ex
 
-export CXXFLAGS="-fPIC ${CXXFLAGS}"
-export CFLAGS="-fPIC ${CFLAGS}"
-
-# Build shared libraries
+mkdir build-cmake
+pushd build-cmake
+cmake ${CMAKE_ARGS} -GNinja \
+  -DCMAKE_PREFIX_PATH=$PREFIX \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DENABLE_TESTING=OFF \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=ON \
+  ..
+ninja install
+popd
+# Also do this installation to get .pc files. This duplicates the compilation but gets us all necessary components without patching.
 make -j "${CPU_COUNT}" prefix=${PREFIX} shared-install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,15 +13,16 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   run_exports:
     - {{ pin_subpackage("re2", max_pin="x.x.x") }}
 
 requirements:
   build:
-    - cmake >=3.4
+    - cmake
     - make
+    - ninja
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:


### PR DESCRIPTION
Required by https://github.com/conda-forge/grpc-cpp-feedstock/pull/74

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
