### PR TITLE
[v2023.09.01] remove implicit `max_pin=x` from run-export

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 5bb6875ae1cd1e9fedde98018c346db7260655f86fdb8837e3075103acd3649b
 
 build:
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -38,7 +38,7 @@ outputs:
     script: install.bat  # [win]
     build:
       run_exports:
-        - {{ pin_subpackage("libre2-" ~ soversion) }}
+        - {{ pin_subpackage("libre2-" ~ soversion, max_pin=None) }}
         # by adding this run-export, we avoid that different libre2-{X,Y} builds
         # can be co-installed, because they then depend on different re2-versions
         # (see below), and each re2 in turn requires a specific soversion.
@@ -88,7 +88,7 @@ outputs:
     script: install.bat  # [win]
     build:
       run_exports:
-        - {{ pin_subpackage("libre2-" ~ soversion) }}
+        - {{ pin_subpackage("libre2-" ~ soversion, max_pin=None) }}
     requirements:
       build:
         # for strong run-exports


### PR DESCRIPTION
Backport #84 so that feedstocks which haven't rerendered yet after https://github.com/conda-forge/conda-forge-pinning-feedstock/commit/22886ad33d3c8031eeecf56261898bd2ddb01443 don't end up causing more wrong run-exports that need to be patched (c.f. https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/879).